### PR TITLE
fix(release): not triggering with automation

### DIFF
--- a/.github/workflows/rpm-astartectl-release.yaml
+++ b/.github/workflows/rpm-astartectl-release.yaml
@@ -1,9 +1,14 @@
 name: rpm-astartectl-release
 on:
   workflow_dispatch:
-  release:
-    types:
-      - released
+    inputs:
+      tag:
+        type: string
+        description: Tag to push the sources to
+        required: true
+  push:
+    tags:
+      - astartectl-v*
 permissions:
   contents: read
 # Spend CI time only on latest ref
@@ -16,9 +21,6 @@ defaults:
 jobs:
   create-sources:
     runs-on: ubuntu-24.04
-    if: |
-      startsWith(github.event.release.tag_name, 'astartectl') ||
-      github.event_name == 'workflow_dispatch'
     container:
       image: fedora:41
     steps:
@@ -52,17 +54,28 @@ jobs:
   upload-to-release:
     runs-on: ubuntu-24.04
     needs: create-sources
-    if: github.event_name == 'release'
     steps:
       - name: download artifacts
         uses: actions/download-artifact@v4
         with:
           name: astartectl-sources
+      - name: get release tag
+        env:
+          PUSH_EVENT: ${{ github.event.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [[ -n "$INPUT_TAG" ]]; then
+            echo "TAG=$INPUT_TAG" >> "$GITHUB_ENV"
+          elif [[ -n "$PUSH_EVENT" ]]; then
+            echo "TAG=$PUSH_EVENT" >> "$GITHUB_ENV"
+          else
+            echo "Couldn't determin release tag"
+            exit 1
+          fi
       - name: upload to relase
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name }}
           WEBHOOK: ${{ secrets.COPR_WEBHOOK }}
         run: |
           find -type f


### PR DESCRIPTION
Since the event was generated by another workflow the release ci wouldn't run.